### PR TITLE
Upsert units with CreatureHydrator

### DIFF
--- a/Assets/Creatures/impl/Cerebrian/Cerebrax/Cerebrax.lock
+++ b/Assets/Creatures/impl/Cerebrian/Cerebrax/Cerebrax.lock
@@ -1,2 +1,0 @@
-Hydration: Complete
-Linked: Complete

--- a/Assets/Creatures/impl/Cerebrian/Cerebrax/Cerebrax.lock.meta
+++ b/Assets/Creatures/impl/Cerebrian/Cerebrax/Cerebrax.lock.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: fee6010f70a45164fb2a88bb939fc748
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Creatures/impl/Cerebrian/Psymite/Psymite.lock
+++ b/Assets/Creatures/impl/Cerebrian/Psymite/Psymite.lock
@@ -1,2 +1,0 @@
-Hydration: Complete
-Linked: Complete

--- a/Assets/Creatures/impl/Cerebrian/Psymite/Psymite.lock.meta
+++ b/Assets/Creatures/impl/Cerebrian/Psymite/Psymite.lock.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 509215beace68df46b6a386ee39543c3
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Creatures/impl/Cerebrian/Synaptogon/Synaptogon.lock
+++ b/Assets/Creatures/impl/Cerebrian/Synaptogon/Synaptogon.lock
@@ -1,2 +1,0 @@
-Hydration: Complete
-Linked: Complete

--- a/Assets/Creatures/impl/Cerebrian/Synaptogon/Synaptogon.lock.meta
+++ b/Assets/Creatures/impl/Cerebrian/Synaptogon/Synaptogon.lock.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 911fd4deff6e4a748a57dfd2bf87ea27
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Creatures/impl/Frigidariant/Cryothor/Cryothor.lock
+++ b/Assets/Creatures/impl/Frigidariant/Cryothor/Cryothor.lock
@@ -1,2 +1,0 @@
-Hydration: Complete
-Linked: Complete

--- a/Assets/Creatures/impl/Frigidariant/Cryothor/Cryothor.lock.meta
+++ b/Assets/Creatures/impl/Frigidariant/Cryothor/Cryothor.lock.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 6b2e467942152da4faa06c161268599e
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Creatures/impl/Frigidariant/Frosthulm/Frosthulm.lock
+++ b/Assets/Creatures/impl/Frigidariant/Frosthulm/Frosthulm.lock
@@ -1,2 +1,0 @@
-Hydration: Complete
-Linked: Complete

--- a/Assets/Creatures/impl/Frigidariant/Frosthulm/Frosthulm.lock.meta
+++ b/Assets/Creatures/impl/Frigidariant/Frosthulm/Frosthulm.lock.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: a06b4d6cbf53d1e4880aa20429689d0e
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Creatures/impl/Frigidariant/Glacili/Glacili.lock
+++ b/Assets/Creatures/impl/Frigidariant/Glacili/Glacili.lock
@@ -1,2 +1,0 @@
-Hydration: Complete
-Linked: Complete

--- a/Assets/Creatures/impl/Frigidariant/Glacili/Glacili.lock.meta
+++ b/Assets/Creatures/impl/Frigidariant/Glacili/Glacili.lock.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: b66c25ffa13f3ce40a9bb125bd834b7a
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Creatures/impl/Magnarok/Emberclad/Emberclad.lock
+++ b/Assets/Creatures/impl/Magnarok/Emberclad/Emberclad.lock
@@ -1,2 +1,0 @@
-Hydration: Complete
-Linked: Complete

--- a/Assets/Creatures/impl/Magnarok/Emberclad/Emberclad.lock.meta
+++ b/Assets/Creatures/impl/Magnarok/Emberclad/Emberclad.lock.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 8968835c1203d9942ad65f89080010a6
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Creatures/impl/Magnarok/Lavaforge/Lavaforge.lock
+++ b/Assets/Creatures/impl/Magnarok/Lavaforge/Lavaforge.lock
@@ -1,2 +1,0 @@
-Hydration: Complete
-Linked: Complete

--- a/Assets/Creatures/impl/Magnarok/Lavaforge/Lavaforge.lock.meta
+++ b/Assets/Creatures/impl/Magnarok/Lavaforge/Lavaforge.lock.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 71e1934f9b8bb724fafae77e2f626394
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Creatures/impl/Magnarok/Pyroclast/Pyroclast.lock
+++ b/Assets/Creatures/impl/Magnarok/Pyroclast/Pyroclast.lock
@@ -1,2 +1,0 @@
-Hydration: Complete
-Linked: Complete

--- a/Assets/Creatures/impl/Magnarok/Pyroclast/Pyroclast.lock.meta
+++ b/Assets/Creatures/impl/Magnarok/Pyroclast/Pyroclast.lock.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: d97fed124c4410f4b9140720a9c162f9
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Creatures/impl/Venoxarid/Serpentide/Run/Run.anim
+++ b/Assets/Creatures/impl/Venoxarid/Serpentide/Run/Run.anim
@@ -17,21 +17,61 @@ AnimationClip:
   m_PositionCurves: []
   m_ScaleCurves: []
   m_FloatCurves: []
-  m_PPtrCurves: []
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: -7415915544246221167, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
+    - time: 0.1
+      value: {fileID: -8524627914538360160, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
+    - time: 0.2
+      value: {fileID: 233265643643166477, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
+    - time: 0.3
+      value: {fileID: -1204764763159528931, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
+    - time: 0.4
+      value: {fileID: 3096167096728842467, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
+    - time: 0.5
+      value: {fileID: 4766418171247014114, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
+    - time: 0.6
+      value: {fileID: -9214475492581043227, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
+    - time: 0.7
+      value: {fileID: 5216498795272401019, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
   m_SampleRate: 60
   m_WrapMode: 2
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -7415915544246221167, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
+    - {fileID: -8524627914538360160, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
+    - {fileID: 233265643643166477, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
+    - {fileID: -1204764763159528931, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
+    - {fileID: 3096167096728842467, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
+    - {fileID: 4766418171247014114, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
+    - {fileID: -9214475492581043227, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
+    - {fileID: 5216498795272401019, guid: 3bc854fc7b59af742befc09cdedc855e, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1
+    m_StopTime: 0.71666664
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/Assets/Creatures/impl/Venoxarid/Serpentide/Run/Run.yml
+++ b/Assets/Creatures/impl/Venoxarid/Serpentide/Run/Run.yml
@@ -2,3 +2,4 @@ canvas:
     height: 128
     width: 116
 frames: 8
+frameRate: 10

--- a/Assets/Creatures/impl/Venoxarid/Serpentide/Serpentide.lock
+++ b/Assets/Creatures/impl/Venoxarid/Serpentide/Serpentide.lock
@@ -1,2 +1,0 @@
-Hydration: Complete
-Linked: Complete

--- a/Assets/Creatures/impl/Venoxarid/Serpentide/Serpentide.lock.meta
+++ b/Assets/Creatures/impl/Venoxarid/Serpentide/Serpentide.lock.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: c1c0108a8c4bb184a9611400e2de2de6
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Creatures/impl/Venoxarid/Serpentide/SerpentideController.controller
+++ b/Assets/Creatures/impl/Venoxarid/Serpentide/SerpentideController.controller
@@ -1,5 +1,49 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1101 &-6475426842647249241
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 0}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 1
+  serializedVersion: 3
+  m_TransitionDuration: 0.1
+  m_TransitionOffset: 0
+  m_ExitTime: 1
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-6334014118209992525
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 0}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 1
+  serializedVersion: 3
+  m_TransitionDuration: 0.1
+  m_TransitionOffset: 0
+  m_ExitTime: 1
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-3767834263443679909
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -67,13 +111,13 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isDead
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -227,6 +271,8 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 3216741531333481121}
+  - {fileID: -6475426842647249241}
+  - {fileID: -6334014118209992525}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/Creatures/impl/Venoxarid/Toxlith/Toxlith.lock
+++ b/Assets/Creatures/impl/Venoxarid/Toxlith/Toxlith.lock
@@ -1,2 +1,0 @@
-Hydration: Complete
-Linked: Complete

--- a/Assets/Creatures/impl/Venoxarid/Toxlith/Toxlith.lock.meta
+++ b/Assets/Creatures/impl/Venoxarid/Toxlith/Toxlith.lock.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 9bdb68b8c73df6d4c857eeb07be103c4
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Creatures/impl/Venoxarid/Venomire/Venomire.lock
+++ b/Assets/Creatures/impl/Venoxarid/Venomire/Venomire.lock
@@ -1,2 +1,0 @@
-Hydration: Complete
-Linked: Complete

--- a/Assets/Creatures/impl/Venoxarid/Venomire/Venomire.lock.meta
+++ b/Assets/Creatures/impl/Venoxarid/Venomire/Venomire.lock.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 4de9e4cb5c47dec4aa88461395c9b3db
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Editor/CreatureHydrator.cs
+++ b/Assets/Editor/CreatureHydrator.cs
@@ -46,18 +46,6 @@ public class CreatureHydrator : Editor
     {
         string unitName = Path.GetFileName(unitDir);
         string unitYamlPath = Path.Combine(unitDir, $"{unitName}.yml");
-        string lockFilePath = Path.Combine(unitDir, $"{unitName}.lock");
-
-        // Skip hydration if the lockfile exists and hydration is complete
-        if (File.Exists(lockFilePath))
-        {
-            var lockFileContent = File.ReadAllText(lockFilePath);
-            if (lockFileContent.Contains("Hydration: Complete"))
-            {
-                Debug.Log($"Skipping hydration for {unitName} because it has already been hydrated.");
-                return;
-            }
-        }
 
         if (!File.Exists(unitYamlPath))
         {
@@ -70,9 +58,6 @@ public class CreatureHydrator : Editor
 
         // Hydrate the creature using the spec and directory
         HydrateCreature(unit, generaName, unitName, unitDir);
-
-        // Create or update a lockfile to indicate that this creature has been hydrated
-        File.WriteAllText(lockFilePath, "Hydration: Complete\nLinked: Incomplete");
     }
 
     private static T DeserializeYaml<T>(string yamlContent)

--- a/Assets/Editor/CreatureLinker.cs
+++ b/Assets/Editor/CreatureLinker.cs
@@ -31,7 +31,6 @@ public class CreatureLinker : Editor
         string unitName = Path.GetFileName(unitDir);
         string scriptPath = Path.Combine(unitDir, $"{unitName}.cs");
         string prefabPath = Path.Combine(unitDir, $"{unitName}.prefab");
-        string lockFilePath = Path.Combine(unitDir, $"{unitName}.lock");
 
         // Check if the script and prefab exist
         if (!File.Exists(scriptPath))
@@ -43,17 +42,6 @@ public class CreatureLinker : Editor
         {
             Debug.LogError($"Prefab for {unitName} not found at {prefabPath}");
             return;
-        }
-
-        // Skip linking if the lockfile indicates that linking is complete
-        if (File.Exists(lockFilePath))
-        {
-            var lockFileContent = File.ReadAllText(lockFilePath);
-            if (lockFileContent.Contains("Linked: Complete"))
-            {
-                Debug.Log($"Skipping linking for {unitName} because it has already been linked.");
-                return;
-            }
         }
 
         // Load the prefab
@@ -203,9 +191,6 @@ public class CreatureLinker : Editor
 
         // Save the updated prefab
         PrefabUtility.SaveAsPrefabAsset(unitPrefab, prefabPath);
-
-        // Update the lockfile to indicate that linking is complete
-        File.WriteAllText(lockFilePath, "Hydration: Complete\nLinked: Complete");
 
         Debug.Log($"{unitName} script linked successfully.");
     }


### PR DESCRIPTION
1. Removes the lockfiles and locking, in favor of _always_ re-hydrating everything
  a. This is because we want to be able to add features and capabilities to the hydrator and be able to roll out those changes to all hydrated units
  b. This carries the decision that we should NOT code directly to any hydrated files, because they will always be overwritten
2. _Upserts_ the changes to the creatures, because if you just create them fresh, it will break links between hydrated and non-hydrated units (e.g. your prefab's ID changes in the backend, and then your unit stops spawning from the existing spawners 😭 ) 